### PR TITLE
Change behaviour of binary search for scanning pb files.

### DIFF
--- a/aa/pb.py
+++ b/aa/pb.py
@@ -128,8 +128,6 @@ def parse_pb_data(raw_data, pv, start, end, count=None):
     events = []
     for year, (chunk_info, lines) in year_chunks.items():
         s = search_events(start, chunk_info, lines) if year == start.year else 0
-        if s == -1:
-            s = 0
         e = search_events(end, chunk_info, lines) if year == end.year else None
         for line in lines[s:e]:
             events.append(event_from_line(line, pv, year, chunk_info.type))

--- a/aa/utils.py
+++ b/aa/utils.py
@@ -69,10 +69,9 @@ def binary_search(seq, f, target):
     lower = 0
     while (upper - lower) > 1:
         current = (upper + lower) // 2
-        next_input = seq[current]
-        val = f(next_input)
-        if val > target:
+        next_val = f(seq[current])
+        if next_val > target:
             upper = current
-        elif val <= target:
+        elif next_val <= target:
             lower = current
     return upper

--- a/aa/utils.py
+++ b/aa/utils.py
@@ -45,12 +45,14 @@ def print_raw_bytes(byte_seq):
 
 
 def binary_search(seq, f, target):
-    """Find no such that f(seq[no]) >= target and f(seq[no+1]) > target.
+    """Find no such that f(seq[no-1]) <= target and f(seq[no]) > target.
 
-    If f(seq[0]) > target, return -1
-    If f(seq[-1]) < target, return len(seq)
+    If target < f(seq[0]), return 0
+    If target > f(seq[-1]), return len(seq)
 
     Assume f(seq[no]) < f(seq[no+1]).
+
+    The integer result is useful for indexing the array.
 
     Args:
         seq: sequence of inputs on which to act
@@ -60,11 +62,11 @@ def binary_search(seq, f, target):
     Returns: index of item in seq meeting search requirements
     """
     if len(seq) == 0 or f(seq[0]) > target:
-        return -1
+        return 0
     elif f(seq[-1]) < target:
         return len(seq)
     upper = len(seq)
-    lower = -1
+    lower = 0
     while (upper - lower) > 1:
         current = (upper + lower) // 2
         next_input = seq[current]
@@ -73,4 +75,4 @@ def binary_search(seq, f, target):
             upper = current
         elif val <= target:
             lower = current
-    return lower
+    return upper

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -56,6 +56,12 @@ def test_binary_search_returns_upper_index():
     assert utils.binary_search([1, 2], f, 1.5) == 1
 
 
+def test_binary_search_returns_upper_index_for_larger_sequence():
+    # This tests an otherwise-untested block in the algorithm.
+    f = lambda x: x
+    assert utils.binary_search([1, 2, 3, 4], f, 3.5) == 3
+
+
 def test_binary_search_returns_index_plus_one_if_value_equals_item_in_seq():
     f = lambda x: x
     assert utils.binary_search([1, 2], f, 1) == 1

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -37,13 +37,13 @@ def test_year_timestamp_gives_correct_answer(year, timestamp):
     assert utils.year_timestamp(year) == timestamp
 
 
-def test_binary_search_raises_IndexError_for_empty_seq():
-    assert utils.binary_search([], lambda x: x, 1) == -1
+def test_binary_search_returns_zero_for_empty_seq():
+    assert utils.binary_search([], lambda x: x, 1) == 0
 
 
-def test_binary_search_returns_minus_one_if_target_below_range():
+def test_binary_search_returns_zero_if_target_below_range():
     f = lambda x: x
-    assert utils.binary_search([2, 3, 4], f, 1) == -1
+    assert utils.binary_search([2, 3, 4], f, 1) == 0
 
 
 def test_binary_search_returns_len_seq_if_target_above_range():
@@ -51,12 +51,12 @@ def test_binary_search_returns_len_seq_if_target_above_range():
     assert utils.binary_search([1, 2, 3], f, 4) == 3
 
 
-def test_binary_search_returns_lower_index():
+def test_binary_search_returns_upper_index():
     f = lambda x: x
-    assert utils.binary_search([1, 2], f, 1.5) == 0
+    assert utils.binary_search([1, 2], f, 1.5) == 1
 
 
-def test_binary_search_returns_index_if_value_equals_item_in_seq():
+def test_binary_search_returns_index_plus_one_if_value_equals_item_in_seq():
     f = lambda x: x
-    assert utils.binary_search([1, 2], f, 1) == 0
+    assert utils.binary_search([1, 2], f, 1) == 1
 


### PR DESCRIPTION
The returned number is now between zero and the length of the input sequence.
These numbers are more useful for indexing the sequence.